### PR TITLE
Most recent enrollment algorithm (MVP render deployment)

### DIFF
--- a/enrollment_predictions/enrollment_predictions.py
+++ b/enrollment_predictions/enrollment_predictions.py
@@ -1,6 +1,6 @@
 from .models.auto_regressor_dec_tree import *
 from .models.most_recent_enroll import *
-import pandas as pd
+# import pandas as pd
 
 def enrollment_predictions(train_data, X):
     train_data = data_preprocessing(train_data)

--- a/enrollment_predictions/enrollment_predictions.py
+++ b/enrollment_predictions/enrollment_predictions.py
@@ -20,16 +20,23 @@ def most_recent_enrollments(historic_schedules, courses):
     season_mapping = {5: 1, 9: 2, 1: 3}
     courses['Season'] = term_month.map(season_mapping)
 
-    predictions = []
+    result = {"estimates": {}}
     for ind in courses.index:
         past_offerings = historic_schedules[historic_schedules["Course"] == courses['Course'][ind]]
         past_offerings = past_offerings[past_offerings["Season"] == courses['Season'][ind]]
         most_recent_offering = past_offerings[past_offerings["Term"] == past_offerings["Term"].max()].iloc[0]
 
-        prediction = {
+        """prediction = {
             "course" : courses['Course'][ind],
             "estimate" : most_recent_offering["Enrolled"]
         }
         predictions.append(prediction)
 
-    return(predictions)
+        result["estimates"].append({
+            "course": courses['Course'][ind],
+            "estimate": most_recent_offering["Enrolled"],
+        })"""
+
+        result["estimates"][courses['Course'][ind]] = most_recent_offering["Enrolled"]
+
+    return(result)

--- a/enrollment_predictions/enrollment_predictions.py
+++ b/enrollment_predictions/enrollment_predictions.py
@@ -1,4 +1,5 @@
 from .models.auto_regressor_dec_tree import *
+import pandas as pd
 
 def enrollment_predictions(train_data, X):
     train_data = data_preprocessing(train_data)
@@ -6,4 +7,29 @@ def enrollment_predictions(train_data, X):
 
     return predict_year(model, X) # Returns a dataframe with one column: 'Predicted'
 
+def most_recent_enrollments(historic_schedules, courses):
+    historic_schedules = pd.DataFrame(historic_schedules)
+    historic_schedules['Course'] = historic_schedules['Subj'] + historic_schedules["Num"]
+    term_month = historic_schedules['Term'].astype(int) % 100
+    season_mapping = {5: 1, 9: 2, 1: 3}
+    historic_schedules['Season'] = term_month.map(season_mapping)
 
+    courses = pd.DataFrame(courses)
+    courses['Course'] = courses['Subj'] + courses["Num"]
+    term_month = courses['Term'].astype(int) % 100
+    season_mapping = {5: 1, 9: 2, 1: 3}
+    courses['Season'] = term_month.map(season_mapping)
+
+    predictions = []
+    for ind in courses.index:
+        past_offerings = historic_schedules[historic_schedules["Course"] == courses['Course'][ind]]
+        past_offerings = past_offerings[past_offerings["Season"] == courses['Season'][ind]]
+        most_recent_offering = past_offerings[past_offerings["Term"] == past_offerings["Term"].max()].iloc[0]
+
+        prediction = {
+            "course" : courses['Course'][ind],
+            "estimate" : most_recent_offering["Enrolled"]
+        }
+        predictions.append(prediction)
+
+    return(predictions)

--- a/enrollment_predictions/enrollment_predictions.py
+++ b/enrollment_predictions/enrollment_predictions.py
@@ -32,12 +32,5 @@ def most_recent_enrollments(historic_schedules, courses):
         }
 
         result["estimates"][courses['Course'][ind]] = prediction
-        """
-        predictions.append(prediction)
-
-        result["estimates"].append({
-            "course": courses['Course'][ind],
-            "estimate": most_recent_offering["Enrolled"],
-        })"""
 
     return(result)

--- a/enrollment_predictions/enrollment_predictions.py
+++ b/enrollment_predictions/enrollment_predictions.py
@@ -26,17 +26,18 @@ def most_recent_enrollments(historic_schedules, courses):
         past_offerings = past_offerings[past_offerings["Season"] == courses['Season'][ind]]
         most_recent_offering = past_offerings[past_offerings["Term"] == past_offerings["Term"].max()].iloc[0]
 
-        """prediction = {
+        prediction = {
             "course" : courses['Course'][ind],
             "estimate" : most_recent_offering["Enrolled"]
         }
+
+        result["estimates"][courses['Course'][ind]] = prediction
+        """
         predictions.append(prediction)
 
         result["estimates"].append({
             "course": courses['Course'][ind],
             "estimate": most_recent_offering["Enrolled"],
         })"""
-
-        result["estimates"][courses['Course'][ind]] = most_recent_offering["Enrolled"]
 
     return(result)

--- a/enrollment_predictions/enrollment_predictions.py
+++ b/enrollment_predictions/enrollment_predictions.py
@@ -1,4 +1,5 @@
 from .models.auto_regressor_dec_tree import *
+from .models.most_recent_enroll import *
 import pandas as pd
 
 def enrollment_predictions(train_data, X):
@@ -8,29 +9,7 @@ def enrollment_predictions(train_data, X):
     return predict_year(model, X) # Returns a dataframe with one column: 'Predicted'
 
 def most_recent_enrollments(historic_schedules, courses):
-    historic_schedules = pd.DataFrame(historic_schedules)
-    historic_schedules['Course'] = historic_schedules['Subj'] + historic_schedules["Num"]
-    term_month = historic_schedules['Term'].astype(int) % 100
-    season_mapping = {5: 1, 9: 2, 1: 3}
-    historic_schedules['Season'] = term_month.map(season_mapping)
-
-    courses = pd.DataFrame(courses)
-    courses['Course'] = courses['Subj'] + courses["Num"]
-    term_month = courses['Term'].astype(int) % 100
-    season_mapping = {5: 1, 9: 2, 1: 3}
-    courses['Season'] = term_month.map(season_mapping)
-
-    result = {"estimates": {}}
-    for ind in courses.index:
-        past_offerings = historic_schedules[historic_schedules["Course"] == courses['Course'][ind]]
-        past_offerings = past_offerings[past_offerings["Season"] == courses['Season'][ind]]
-        most_recent_offering = past_offerings[past_offerings["Term"] == past_offerings["Term"].max()].iloc[0]
-
-        prediction = {
-            "course" : courses['Course'][ind],
-            "estimate" : most_recent_offering["Enrolled"]
-        }
-
-        result["estimates"][courses['Course'][ind]] = prediction
+    historic_schedules = data_preprocessing(historic_schedules)
+    result = predict_year(historic_schedules, courses)
 
     return(result)

--- a/enrollment_predictions/enrollment_predictions.py
+++ b/enrollment_predictions/enrollment_predictions.py
@@ -9,7 +9,7 @@ def enrollment_predictions(train_data, X):
     return predict_year(model, X) # Returns a dataframe with one column: 'Predicted'
 
 def most_recent_enrollments(historic_schedules, courses):
-    historic_schedules = data_preprocessing(historic_schedules)
-    result = predict_year(historic_schedules, courses)
+    historic_schedules = most_recent_data_preprocessing(historic_schedules)
+    result = most_recent_predict_year(historic_schedules, courses)
 
     return(result)

--- a/enrollment_predictions/models/most_recent_enroll.py
+++ b/enrollment_predictions/models/most_recent_enroll.py
@@ -7,6 +7,8 @@ def most_recent_data_preprocessing(historic_schedules):
     season_mapping = {5: 1, 9: 2, 1: 3}
     historic_schedules['Season'] = term_month.map(season_mapping)
 
+    return(historic_schedules)
+
 def most_recent_predict_year(historic_schedules, courses):
     courses = pd.DataFrame(courses)
     courses['Course'] = courses['Subj'] + courses["Num"]

--- a/enrollment_predictions/models/most_recent_enroll.py
+++ b/enrollment_predictions/models/most_recent_enroll.py
@@ -1,0 +1,30 @@
+import pandas as pd
+
+def data_preprocessing(historic_schedules):
+    historic_schedules = pd.DataFrame(historic_schedules)
+    historic_schedules['Course'] = historic_schedules['Subj'] + historic_schedules["Num"]
+    term_month = historic_schedules['Term'].astype(int) % 100
+    season_mapping = {5: 1, 9: 2, 1: 3}
+    historic_schedules['Season'] = term_month.map(season_mapping)
+
+def predict_year(historic_schedules, courses):
+    courses = pd.DataFrame(courses)
+    courses['Course'] = courses['Subj'] + courses["Num"]
+    term_month = courses['Term'].astype(int) % 100
+    season_mapping = {5: 1, 9: 2, 1: 3}
+    courses['Season'] = term_month.map(season_mapping)
+
+    result = {"estimates": {}}
+    for ind in courses.index:
+        past_offerings = historic_schedules[historic_schedules["Course"] == courses['Course'][ind]]
+        past_offerings = past_offerings[past_offerings["Season"] == courses['Season'][ind]]
+        most_recent_offering = past_offerings[past_offerings["Term"] == past_offerings["Term"].max()].iloc[0]
+
+        prediction = {
+            "course" : courses['Course'][ind],
+            "estimate" : most_recent_offering["Enrolled"]
+        }
+
+        result["estimates"][courses['Course'][ind]] = prediction
+    
+    return(result)

--- a/enrollment_predictions/models/most_recent_enroll.py
+++ b/enrollment_predictions/models/most_recent_enroll.py
@@ -1,13 +1,13 @@
 import pandas as pd
 
-def data_preprocessing(historic_schedules):
+def most_recent_data_preprocessing(historic_schedules):
     historic_schedules = pd.DataFrame(historic_schedules)
     historic_schedules['Course'] = historic_schedules['Subj'] + historic_schedules["Num"]
     term_month = historic_schedules['Term'].astype(int) % 100
     season_mapping = {5: 1, 9: 2, 1: 3}
     historic_schedules['Season'] = term_month.map(season_mapping)
 
-def predict_year(historic_schedules, courses):
+def most_recent_predict_year(historic_schedules, courses):
     courses = pd.DataFrame(courses)
     courses['Course'] = courses['Subj'] + courses["Num"]
     term_month = courses['Term'].astype(int) % 100

--- a/enrollment_predictions/models/most_recent_enroll.py
+++ b/enrollment_predictions/models/most_recent_enroll.py
@@ -19,12 +19,16 @@ def most_recent_predict_year(historic_schedules, courses):
     result = {"estimates": {}}
     for ind in courses.index:
         past_offerings = historic_schedules[historic_schedules["Course"] == courses['Course'][ind]]
-        past_offerings = past_offerings[past_offerings["Season"] == courses['Season'][ind]]
-        most_recent_offering = past_offerings[past_offerings["Term"] == past_offerings["Term"].max()].iloc[0]
+        try:
+            past_offerings = past_offerings[past_offerings["Season"] == courses['Season'][ind]]
+            most_recent_offering = past_offerings[past_offerings["Term"] == past_offerings["Term"].max()].iloc[0]
+            estimate = most_recent_offering["Enrolled"]
+        except:
+            estimate = 0
 
         prediction = {
             "course" : courses['Course'][ind],
-            "estimate" : most_recent_offering["Enrolled"]
+            "estimate" : estimate
         }
 
         result["estimates"][courses['Course'][ind]] = prediction

--- a/prediction_service/scripts/test_endpoint.py
+++ b/prediction_service/scripts/test_endpoint.py
@@ -1,10 +1,41 @@
 import requests
 import json
 
-base_url = 'http://localhost:8001'
+# base_url = 'http://localhost:8001'
+base_url = 'https://algs2.onrender.com'
 
 url = f'{base_url}/predict'
-body = {'year':'2022', 'term':'spring'}
+courses = [
+        {
+	"name": "Fundamentals of Programming with Engineering Applications",
+	"shorthand": "CSC115",
+	"prerequisites": [["CSC110"], ["CSC111"]],
+	"corequisites": [[""]],
+	"terms_offered": ["fall", "spring", "summer"]
+	},
+	{
+	"name": "",
+	"shorthand": "CSC320",
+	"prerequisites": [[""]],
+	"corequisites": [[""]],
+	"terms_offered": ["fall", "spring", "summer"]
+	},
+	{
+	"name": "",
+	"shorthand": "SENG265",
+	"prerequisites": [[""]],
+	"corequisites": [[""]],
+	"terms_offered": ["fall", "spring", "summer"]
+	},
+	{
+	"name": "",
+	"shorthand": "SENG499",
+	"prerequisites": [[""]],
+	"corequisites": [[""]],
+	"terms_offered": ["fall", "spring", "summer"]
+	}
+]
+body = {'year':'2023', 'term':'summer', 'courses':courses}
 response = requests.post(url, json = body, headers = {'Content-Type': 'application/json'})
 print(response.status_code)
 print(response._content)

--- a/prediction_service/views.py
+++ b/prediction_service/views.py
@@ -50,7 +50,10 @@ def predict(request):
     predictions = utils.reformat_predictions(courses, predictions)"""
 
     # Use simple prediction until we can use decision tree
-    predictions = most_recent_enrollments(historic_schedules, courses)
+    try:
+        predictions = most_recent_enrollments(historic_schedules, courses)
+    except Exception as e:
+        return HttpResponse(f"oop{e}", status=400)
         
     try:
         return JsonResponse(predictions, status=200) 

--- a/prediction_service/views.py
+++ b/prediction_service/views.py
@@ -41,6 +41,7 @@ def predict(request):
         predictions = most_recent_enrollments(historic_schedules, courses, year, term)
     except Exception as e:
         return HttpResponse(f"oop {e}", status=400)
+    return HttpResponse("got this far", status=400)
     """ TODO: Uncomment when decision tree is ready
     courses = utils.filter_courses_by_term(courses, term)
 

--- a/prediction_service/views.py
+++ b/prediction_service/views.py
@@ -25,28 +25,25 @@ def predict(request):
     """ TODO: Uncomment this when backend is ready
     # Get historic schedules from backend
     historic_schedules = api.request_historic_schedules()
-
-    # Reformat schedules for prediction
-    historic_schedules = utils.reformat_schedules(historic_schedules)
     """ # TODO: Remove this when backend is ready
     with open('data/client_data/schedules.json', 'r', encoding='utf-8') as fh:
         historic_schedules = json.load(fh)
+    # Reformat schedules for prediction
+    historic_schedules = utils.reformat_schedules(historic_schedules)
 
     # Get courses from request
     courses = data.get('courses')
     ## Get courses from backend
     ## courses = api.request_courses()
 
-    try:
-        predictions = most_recent_enrollments(historic_schedules, courses, year, term)
-    except Exception as e:
-        return HttpResponse(f"oop {e}", status=400)
-    """ TODO: Uncomment when decision tree is ready
-    courses = utils.filter_courses_by_term(courses, term)
-
+    # Simple prediction until decision tree is ready
+    predictions = most_recent_enrollments(historic_schedules, courses, year, term)
+    
     # Reformat courses for prediction
+    courses = utils.filter_courses_by_term(courses, term)
     courses = utils.reformat_courses(courses, year, term)
 
+    """ TODO: Uncomment when decision tree is ready
     # Perform prediction
     predictions = enrollment_predictions(historic_schedules, courses)
 
@@ -55,9 +52,9 @@ def predict(request):
     
     try:
         #predictions = json.dumps(predictions, indent=2)
-        return JsonResponse(predictions, safe=False, status=200) 
+        return JsonResponse(predictions, status=200) 
     except:
-        return HttpResponse(f"got this far{predictions}", status=400)
+        return HttpResponse(f"{predictions}", status=400)
 
     '''
     # If no schedule is returned, perform simple prediction
@@ -76,15 +73,12 @@ def predict(request):
     '''
 
 def most_recent_enrollments(historic_schedules, courses, year, term):
-    historic_schedules = utils.reformat_schedules(historic_schedules)
     historic_schedules = pd.DataFrame(historic_schedules)
     historic_schedules['Course'] = historic_schedules['Subj'] + historic_schedules["Num"]
     term_month = historic_schedules['Term'].astype(int) % 100
     season_mapping = {5: 1, 9: 2, 1: 3}
     historic_schedules['Season'] = term_month.map(season_mapping)
 
-    courses = utils.filter_courses_by_term(courses, term)
-    courses = utils.reformat_courses(courses, year, term)
     courses = pd.DataFrame(courses)
     courses['Course'] = courses['Subj'] + courses["Num"]
     term_month = courses['Term'].astype(int) % 100

--- a/prediction_service/views.py
+++ b/prediction_service/views.py
@@ -3,6 +3,7 @@ from .modules import utils
 from django.http import HttpResponse, JsonResponse
 from enrollment_predictions.enrollment_predictions import enrollment_predictions
 import json
+import pandas as pd
 
 def predict(request):
     # Check that request is a POST request
@@ -36,6 +37,8 @@ def predict(request):
     ## Get courses from backend
     ## courses = api.request_courses()
 
+    predictions = most_recent_enrollments(historic_schedules, courses)
+    """ TODO: Uncomment when decision tree is ready
     courses = utils.filter_courses_by_term(courses, term)
 
     # Reformat courses for prediction
@@ -45,7 +48,7 @@ def predict(request):
     predictions = enrollment_predictions(historic_schedules, courses)
 
     # Reformate predictions
-    predictions = utils.reformat_predictions(courses, predictions)
+    predictions = utils.reformat_predictions(courses, predictions)"""
     
     return JsonResponse(predictions, status=200) 
 
@@ -64,3 +67,59 @@ def predict(request):
         # score = perform_decision_tree()
     #TODO: Return predictions to backend (json)
     '''
+
+def most_recent_enrollments(historic_schedules, courses):
+    historic_schedules = utils.reformat_schedules(historic_schedules)
+    historic_schedules = pd.DataFrame(historic_schedules)
+    historic_schedules['Course'] = historic_schedules['Subj'] + historic_schedules["Num"]
+    term_month = historic_schedules['Term'].astype(int) % 100
+    season_mapping = {5: 1, 9: 2, 1: 3}
+    historic_schedules['Season'] = term_month.map(season_mapping)
+
+    courses = utils.filter_courses_by_term(courses, term)
+    courses = utils.reformat_courses(courses, year, term)
+    courses = pd.DataFrame(courses)
+    courses['Course'] = courses['Subj'] + courses["Num"]
+    term_month = courses['Term'].astype(int) % 100
+    season_mapping = {5: 1, 9: 2, 1: 3}
+    courses['Season'] = term_month.map(season_mapping)
+
+    predictions = []
+    for ind in courses.index:
+        past_offerings = historic_schedules[historic_schedules["Course"] == courses['Course'][ind]]
+        past_offerings = past_offerings[past_offerings["Season"] == courses['Season'][ind]]
+        most_recent_offering = past_offerings[past_offerings["Term"] == past_offerings["Term"].max()].iloc[0]
+
+        prediction = {
+            "course" : courses['Course'][ind],
+            "estimate" : most_recent_offering["Enrolled"]
+        }
+        predictions.append(prediction)
+
+    return(predictions)
+
+if __name__ == '__main__':
+    with open('data/client_data/schedules.json', 'r', encoding='utf-8') as fh:
+        historic_schedules = json.load(fh)
+
+    courses = [
+        {
+            "name": "Fundamentals of Programming with Engineering Applications",
+            "shorthand": "CSC115",
+            "prerequisites": [["CSC110"], ["CSC111"]],
+            "corequisites": [[""]],
+            "terms_offered": ["fall", "spring", "summer"]
+        },
+        {
+            "name": "Foundations of Computer Science",
+            "shorthand": "CSC320",
+            "prerequisites": [["CSC225"], ["CSC226"]],
+            "corequisites": [[""]],
+            "terms_offered": ["fall", "spring", "summer"]
+        }
+    ]
+    term = 'fall'
+    year = '2023'
+    
+    predictions = most_recent_enrollments(historic_schedules, courses)
+    print(predictions)

--- a/prediction_service/views.py
+++ b/prediction_service/views.py
@@ -1,7 +1,7 @@
 from .modules import api
 from .modules import utils
 from django.http import HttpResponse, JsonResponse
-from enrollment_predictions.enrollment_predictions import enrollment_predictions
+from enrollment_predictions.enrollment_predictions import enrollment_predictions, most_recent_enrollments
 import json
 import pandas as pd
 
@@ -75,33 +75,6 @@ def predict(request):
         # score = perform_decision_tree()
     #TODO: Return predictions to backend (json)
     '''
-
-def most_recent_enrollments(historic_schedules, courses):
-    historic_schedules = pd.DataFrame(historic_schedules)
-    historic_schedules['Course'] = historic_schedules['Subj'] + historic_schedules["Num"]
-    term_month = historic_schedules['Term'].astype(int) % 100
-    season_mapping = {5: 1, 9: 2, 1: 3}
-    historic_schedules['Season'] = term_month.map(season_mapping)
-
-    courses = pd.DataFrame(courses)
-    courses['Course'] = courses['Subj'] + courses["Num"]
-    term_month = courses['Term'].astype(int) % 100
-    season_mapping = {5: 1, 9: 2, 1: 3}
-    courses['Season'] = term_month.map(season_mapping)
-
-    predictions = []
-    for ind in courses.index:
-        past_offerings = historic_schedules[historic_schedules["Course"] == courses['Course'][ind]]
-        past_offerings = past_offerings[past_offerings["Season"] == courses['Season'][ind]]
-        most_recent_offering = past_offerings[past_offerings["Term"] == past_offerings["Term"].max()].iloc[0]
-
-        prediction = {
-            "course" : courses['Course'][ind],
-            "estimate" : most_recent_offering["Enrolled"]
-        }
-        predictions.append(prediction)
-
-    return(predictions)
 
 if __name__ == '__main__':
     with open('data/client_data/schedules.json', 'r', encoding='utf-8') as fh:

--- a/prediction_service/views.py
+++ b/prediction_service/views.py
@@ -57,7 +57,7 @@ def predict(request):
         #predictions = json.dumps(predictions, indent=2)
         return JsonResponse(predictions, safe=False, status=200) 
     except:
-        return HttpResponse("got this far", status=400)
+        return HttpResponse(f"got this far{predictions}", status=400)
 
     '''
     # If no schedule is returned, perform simple prediction

--- a/prediction_service/views.py
+++ b/prediction_service/views.py
@@ -38,10 +38,9 @@ def predict(request):
     ## courses = api.request_courses()
 
     try:
-        predictions = most_recent_enrollments(historic_schedules, courses)
+        predictions = most_recent_enrollments(historic_schedules, courses, year, term)
     except Exception as e:
         return HttpResponse(f"oop {e}", status=400)
-    return HttpResponse("got this far", status=400)
     """ TODO: Uncomment when decision tree is ready
     courses = utils.filter_courses_by_term(courses, term)
 

--- a/prediction_service/views.py
+++ b/prediction_service/views.py
@@ -71,7 +71,7 @@ def predict(request):
     #TODO: Return predictions to backend (json)
     '''
 
-def most_recent_enrollments(historic_schedules, courses):
+def most_recent_enrollments(historic_schedules, courses, year, term):
     historic_schedules = utils.reformat_schedules(historic_schedules)
     historic_schedules = pd.DataFrame(historic_schedules)
     historic_schedules['Course'] = historic_schedules['Subj'] + historic_schedules["Num"]

--- a/prediction_service/views.py
+++ b/prediction_service/views.py
@@ -36,14 +36,16 @@ def predict(request):
     ## Get courses from backend
     ## courses = api.request_courses()
 
-    # Simple prediction until decision tree is ready
-    predictions = most_recent_enrollments(historic_schedules, courses, year, term)
-    
-    # Reformat courses for prediction
+    try:
+        predictions = most_recent_enrollments(historic_schedules, courses, year, term)
+    except Exception as e:
+        return HttpResponse(f"oop {e}", status=400)
+    """ TODO: Uncomment when decision tree is ready
     courses = utils.filter_courses_by_term(courses, term)
+
+    # Reformat courses for prediction
     courses = utils.reformat_courses(courses, year, term)
 
-    """ TODO: Uncomment when decision tree is ready
     # Perform prediction
     predictions = enrollment_predictions(historic_schedules, courses)
 
@@ -79,6 +81,8 @@ def most_recent_enrollments(historic_schedules, courses, year, term):
     season_mapping = {5: 1, 9: 2, 1: 3}
     historic_schedules['Season'] = term_month.map(season_mapping)
 
+    courses = utils.filter_courses_by_term(courses, term)
+    courses = utils.reformat_courses(courses, year, term)
     courses = pd.DataFrame(courses)
     courses['Course'] = courses['Subj'] + courses["Num"]
     term_month = courses['Term'].astype(int) % 100

--- a/prediction_service/views.py
+++ b/prediction_service/views.py
@@ -37,7 +37,11 @@ def predict(request):
     ## Get courses from backend
     ## courses = api.request_courses()
 
-    predictions = most_recent_enrollments(historic_schedules, courses)
+    try:
+        predictions = most_recent_enrollments(historic_schedules, courses)
+    except Exception as e:
+        return HttpResponse(f"oop {e}", status=400)
+    return HttpResponse("got this far", status=400)
     """ TODO: Uncomment when decision tree is ready
     courses = utils.filter_courses_by_term(courses, term)
 

--- a/prediction_service/views.py
+++ b/prediction_service/views.py
@@ -49,16 +49,13 @@ def predict(request):
     # Reformate predictions
     predictions = utils.reformat_predictions(courses, predictions)"""
 
+    # Use simple prediction until we can use decision tree
+    predictions = most_recent_enrollments(historic_schedules, courses)
+        
     try:
-        predictions = most_recent_enrollments(historic_schedules, courses)
-    except Exception as e:
-        return HttpResponse(f"oop {e}", status=400)
-    
-    try:
-        #predictions = json.dumps(predictions, indent=2)
         return JsonResponse(predictions, status=200) 
     except:
-        return HttpResponse(f"{predictions}", status=400)
+        return HttpResponse(f"{predictions}", status=200)
 
     '''
     # If no schedule is returned, perform simple prediction
@@ -75,29 +72,3 @@ def predict(request):
         # score = perform_decision_tree()
     #TODO: Return predictions to backend (json)
     '''
-
-if __name__ == '__main__':
-    with open('data/client_data/schedules.json', 'r', encoding='utf-8') as fh:
-        historic_schedules = json.load(fh)
-
-    courses = [
-        {
-            "name": "Fundamentals of Programming with Engineering Applications",
-            "shorthand": "CSC115",
-            "prerequisites": [["CSC110"], ["CSC111"]],
-            "corequisites": [[""]],
-            "terms_offered": ["fall", "spring", "summer"]
-        },
-        {
-            "name": "Foundations of Computer Science",
-            "shorthand": "CSC320",
-            "prerequisites": [["CSC225"], ["CSC226"]],
-            "corequisites": [[""]],
-            "terms_offered": ["fall", "spring", "summer"]
-        }
-    ]
-    term = 'fall'
-    year = '2023'
-    
-    predictions = most_recent_enrollments(historic_schedules, courses)
-    print(predictions)

--- a/prediction_service/views.py
+++ b/prediction_service/views.py
@@ -41,7 +41,6 @@ def predict(request):
         predictions = most_recent_enrollments(historic_schedules, courses, year, term)
     except Exception as e:
         return HttpResponse(f"oop {e}", status=400)
-    return HttpResponse("got this far", status=400)
     """ TODO: Uncomment when decision tree is ready
     courses = utils.filter_courses_by_term(courses, term)
 
@@ -54,7 +53,11 @@ def predict(request):
     # Reformate predictions
     predictions = utils.reformat_predictions(courses, predictions)"""
     
-    return JsonResponse(predictions, status=200) 
+    try:
+        predictions = json.dumps(predictions, indent=2)
+        return JsonResponse(predictions, status=200) 
+    except:
+        return HttpResponse("got this far", status=400)
 
     '''
     # If no schedule is returned, perform simple prediction

--- a/prediction_service/views.py
+++ b/prediction_service/views.py
@@ -26,8 +26,10 @@ def predict(request):
     # Get historic schedules from backend
     historic_schedules = api.request_historic_schedules()
     """ # TODO: Remove this when backend is ready
+
     with open('data/client_data/schedules.json', 'r', encoding='utf-8') as fh:
         historic_schedules = json.load(fh)
+    
     # Reformat schedules for prediction
     historic_schedules = utils.reformat_schedules(historic_schedules)
 
@@ -36,9 +38,8 @@ def predict(request):
     ## Get courses from backend
     ## courses = api.request_courses()
 
-    courses = utils.filter_courses_by_term(courses, term)
-
     # Reformat courses for prediction
+    courses = utils.filter_courses_by_term(courses, term)
     courses = utils.reformat_courses(courses, year, term)
 
     """ TODO: Uncomment when decision tree is ready
@@ -49,7 +50,7 @@ def predict(request):
     predictions = utils.reformat_predictions(courses, predictions)"""
 
     try:
-        predictions = most_recent_enrollments(historic_schedules, courses, year, term)
+        predictions = most_recent_enrollments(historic_schedules, courses)
     except Exception as e:
         return HttpResponse(f"oop {e}", status=400)
     
@@ -75,15 +76,13 @@ def predict(request):
     #TODO: Return predictions to backend (json)
     '''
 
-def most_recent_enrollments(historic_schedules, courses, year, term):
+def most_recent_enrollments(historic_schedules, courses):
     historic_schedules = pd.DataFrame(historic_schedules)
     historic_schedules['Course'] = historic_schedules['Subj'] + historic_schedules["Num"]
     term_month = historic_schedules['Term'].astype(int) % 100
     season_mapping = {5: 1, 9: 2, 1: 3}
     historic_schedules['Season'] = term_month.map(season_mapping)
 
-    #courses = utils.filter_courses_by_term(courses, term)
-    #courses = utils.reformat_courses(courses, year, term)
     courses = pd.DataFrame(courses)
     courses['Course'] = courses['Subj'] + courses["Num"]
     term_month = courses['Term'].astype(int) % 100

--- a/prediction_service/views.py
+++ b/prediction_service/views.py
@@ -21,8 +21,6 @@ def predict(request):
         return HttpResponse("term is required", status=400)
     if not term in ["fall", "spring", "summer"]:
         return HttpResponse("term must be fall, spring, or summer", status=400)
-    if not courses:
-        return HttpResponse("courses to predict are required", status=400)
 
     """ TODO: Uncomment this when backend is ready
     # Get historic schedules from backend
@@ -37,6 +35,8 @@ def predict(request):
 
     # Get courses from request
     courses = data.get('courses')
+    if not courses:
+        return HttpResponse("courses to predict are required", status=400)
     ## Get courses from backend
     ## courses = api.request_courses()
 

--- a/prediction_service/views.py
+++ b/prediction_service/views.py
@@ -21,6 +21,8 @@ def predict(request):
         return HttpResponse("term is required", status=400)
     if not term in ["fall", "spring", "summer"]:
         return HttpResponse("term must be fall, spring, or summer", status=400)
+    if not courses:
+        return HttpResponse("courses to predict are required", status=400)
 
     """ TODO: Uncomment this when backend is ready
     # Get historic schedules from backend
@@ -53,7 +55,7 @@ def predict(request):
     try:
         predictions = most_recent_enrollments(historic_schedules, courses)
     except Exception as e:
-        return HttpResponse(f"oop{e}", status=400)
+        return HttpResponse(f"Error calculating course predictions {e}", status=400)
         
     try:
         return JsonResponse(predictions, status=200) 

--- a/prediction_service/views.py
+++ b/prediction_service/views.py
@@ -36,21 +36,22 @@ def predict(request):
     ## Get courses from backend
     ## courses = api.request_courses()
 
-    try:
-        predictions = most_recent_enrollments(historic_schedules, courses, year, term)
-    except Exception as e:
-        return HttpResponse(f"oop {e}", status=400)
-    """ TODO: Uncomment when decision tree is ready
     courses = utils.filter_courses_by_term(courses, term)
 
     # Reformat courses for prediction
     courses = utils.reformat_courses(courses, year, term)
 
+    """ TODO: Uncomment when decision tree is ready
     # Perform prediction
     predictions = enrollment_predictions(historic_schedules, courses)
 
     # Reformate predictions
     predictions = utils.reformat_predictions(courses, predictions)"""
+
+    try:
+        predictions = most_recent_enrollments(historic_schedules, courses, year, term)
+    except Exception as e:
+        return HttpResponse(f"oop {e}", status=400)
     
     try:
         #predictions = json.dumps(predictions, indent=2)
@@ -81,8 +82,8 @@ def most_recent_enrollments(historic_schedules, courses, year, term):
     season_mapping = {5: 1, 9: 2, 1: 3}
     historic_schedules['Season'] = term_month.map(season_mapping)
 
-    courses = utils.filter_courses_by_term(courses, term)
-    courses = utils.reformat_courses(courses, year, term)
+    #courses = utils.filter_courses_by_term(courses, term)
+    #courses = utils.reformat_courses(courses, year, term)
     courses = pd.DataFrame(courses)
     courses['Course'] = courses['Subj'] + courses["Num"]
     term_month = courses['Term'].astype(int) % 100

--- a/prediction_service/views.py
+++ b/prediction_service/views.py
@@ -54,8 +54,8 @@ def predict(request):
     predictions = utils.reformat_predictions(courses, predictions)"""
     
     try:
-        predictions = json.dumps(predictions, indent=2)
-        return JsonResponse(predictions, status=200) 
+        #predictions = json.dumps(predictions, indent=2)
+        return JsonResponse(predictions, safe=False, status=200) 
     except:
         return HttpResponse("got this far", status=400)
 


### PR DESCRIPTION
The decision tree doesn't work with our new data yet, and since we're presenting on Friday I wanted to make sure we have a minimum viable product deployed on render. So I implemented a simple algorithm that returns the most recent class size (from either the Fall, Spring, or Summer term) for each requested course prediction.

A problem that still hasn't been resolved is that I can't get JsonResponse to output the 'results' dictionary properly, so I return the dictionary through a formatted string in an HttpResponse for now. The main branch also seems to have this problem, since the function that formats our output data for the JsonResponse, utils.reformat_predictions(), doesn't work properly, using list.append() on a dictionary which gives an error.